### PR TITLE
docs: add if cuda available

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ import torch
 from languagebind import LanguageBind, to_device, transform_dict, LanguageBindImageTokenizer
 
 if __name__ == '__main__':
-    device = 'cuda:0'
+    device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
     device = torch.device(device)
     clip_type = ('thermal', 'image', 'video', 'depth', 'audio')
     model = LanguageBind(clip_type=clip_type, cache_dir='./cache_dir')


### PR DESCRIPTION
Hi,
I encountered a bug when performing inference without a GPU. It appears that your code defaults to expecting CUDA. I believe your code could be made more versatile by incorporating an if-else case to handle both GPU and CPU devices.

Thank you for reviewing my pull request.